### PR TITLE
add shell script boilerplate

### DIFF
--- a/_build/scripts/prebuild.sh
+++ b/_build/scripts/prebuild.sh
@@ -1,4 +1,5 @@
 # Prerequisites to run tests or local server
+set -euo pipefail
 
 echo "Installing build packages..." && npm --prefix=_build install --no-audit --no-fund
 echo "Installing front-end packages..." && npm --prefix=front_end install --no-audit --no-fund

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 . _build/scripts/prebuild.sh
 

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 . _build/scripts/prebuild.sh
 node _build/scripts/run_build.js clean

--- a/integrate.sh
+++ b/integrate.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 . _build/scripts/prebuild.sh
 

--- a/serve_dev.sh
+++ b/serve_dev.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 . _build/scripts/prebuild.sh
 node _build/scripts/serve_dev.js "$@"


### PR DESCRIPTION
By default shell scripts don't fail if one of the statements fail, but we usually wish they would, especially if they are automating build processes.

`set -euo pipefail` is a good 2nd line for every shell script:
- `set -e` - fail script if a statement fails.
- `set -u` reading an uninitialized variable is an error
- `-o pipefail` - if one statement in a pipeline fails, fail the pipeline
