### PR TITLE
IntelliJ support for Node.js core modules in .ts files

### DIFF
--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -17,11 +17,13 @@
         "@sinonjs/fake-timers": "^10.1.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
+        "@types/node": "^18.15.3",
         "@types/react": "^18.2.0",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "chai": "^4.3.7",
         "global-jsdom": "^9.0.1",
-        "jsdom": "^22.0.0"
+        "jsdom": "^22.0.0",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -214,6 +216,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
       "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -1464,6 +1472,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/universalify": {

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -14,10 +14,12 @@
     "@sinonjs/fake-timers": "^10.1.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@types/node": "^18.15.3",
     "@types/react": "^18.2.0",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "chai": "^4.3.7",
     "global-jsdom": "^9.0.1",
-    "jsdom": "^22.0.0"
+    "jsdom": "^22.0.0",
+    "typescript": "^5.0.4"
   }
 }

--- a/front_end/tsconfig.json
+++ b/front_end/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}


### PR DESCRIPTION
IntelliJ did not recognize `node:http` in .ts files inside of the front_end module.

This PR adds typescipt to the front_end package dependencies and references the base tsconfig.json in the sub-module.